### PR TITLE
Add vertex_ai/ prefix to model names for clarity

### DIFF
--- a/src/App.svelte
+++ b/src/App.svelte
@@ -141,6 +141,26 @@ We also need to update [${RESOURCE_BACKUP_NAME}](https://github.com/${REPO_FULL_
     });
   }
 
+  /**
+   * Get the display name for a model, adding provider prefix when needed.
+   * This helps users understand which auth method is required.
+   * e.g., "gemini-2.0-flash" with provider "vertex_ai-language-models" -> "vertex_ai/gemini-2.0-flash"
+   */
+  function getDisplayModelName(name: string, litellm_provider: string): string {
+    // If the model name already has a provider prefix, return as-is
+    if (name.includes('/')) {
+      return name;
+    }
+
+    // Add prefix for vertex_ai models so users know they need GCP credentials
+    // Provider can be "vertex_ai", "vertex_ai-language-models", etc.
+    if (litellm_provider && litellm_provider.startsWith('vertex_ai')) {
+      return `vertex_ai/${name}`;
+    }
+
+    return name;
+  }
+
   function toggleRow(name: string) {
     if (expandedRows.has(name)) {
       expandedRows.delete(name);
@@ -329,10 +349,10 @@ We also need to update [${RESOURCE_BACKUP_NAME}](https://github.com/${REPO_FULL_
                       </div>
                     {/if}
                   </div>
-                  <span class="model-title">{name}</span>
-                  <button 
-                    class="copy-button" 
-                    on:click|stopPropagation={() => copyToClipboard(name)}
+                  <span class="model-title">{getDisplayModelName(name, litellm_provider)}</span>
+                  <button
+                    class="copy-button"
+                    on:click|stopPropagation={() => copyToClipboard(getDisplayModelName(name, litellm_provider))}
                     title="Copy model name"
                     type="button"
                   >


### PR DESCRIPTION
## Summary
- Models with `litellm_provider` starting with `vertex_ai` now display with the `vertex_ai/` prefix when the model name doesn't already include a provider prefix
- This helps users understand that these models require GCP/Vertex AI credentials rather than simple API key authentication
- Copying model names also copies the prefixed version

## Context
Related to LiteLLM issue #8424 - users were confused that models like `gemini-2.0-flash` (without prefix) default to Vertex AI and require GCP credentials, not simple API key auth.
<img width="1260" height="684" alt="Screenshot 2026-01-21 at 11 36 10" src="https://github.com/user-attachments/assets/87c53d2c-528c-492a-a0a1-e16b61c87c0f" />
<img width="1248" height="685" alt="Screenshot 2026-01-21 at 11 36 28" src="https://github.com/user-attachments/assets/bb8d3f8c-f279-4911-8ea2-adb62b42a2f3" />



