### PR TITLE
Make stat cards clickable to navigate to relevant tabs

### DIFF
--- a/src/Main.svelte
+++ b/src/Main.svelte
@@ -233,22 +233,22 @@
   {#if !statsLoading}
     <div class="stats-section">
       <div class="stats-container">
-        <div class="stat-card">
+        <button class="stat-card" on:click={() => selectTab("models")}>
           <div class="stat-value">{modelCount}</div>
           <div class="stat-label">Models Supported</div>
-        </div>
-        <div class="stat-card">
+        </button>
+        <button class="stat-card" on:click={() => selectTab("providers")}>
           <div class="stat-value">{providerCount}</div>
           <div class="stat-label">Providers</div>
-        </div>
-        <div class="stat-card">
+        </button>
+        <button class="stat-card" on:click={() => selectTab("providers")}>
           <div class="stat-value">{endpointCount}</div>
           <div class="stat-label">Unique Endpoints</div>
-        </div>
-        <div class="stat-card">
+        </button>
+        <button class="stat-card" on:click={() => selectTab("providers")}>
           <div class="stat-value">{providerEndpointCount}</div>
           <div class="stat-label">Provider + Endpoint Combinations</div>
-        </div>
+        </button>
       </div>
     </div>
   {/if}
@@ -630,6 +630,9 @@
     padding: 0.875rem 0.75rem;
     text-align: center;
     transition: background-color 0.2s ease, border-color 0.2s ease;
+    cursor: pointer;
+    font-family: inherit;
+    width: 100%;
   }
 
   .stat-card:hover {


### PR DESCRIPTION
## Summary
- Stat cards in the header are now clickable
- "Models Supported" navigates to the Models tab
- "Providers", "Unique Endpoints", and "Provider + Endpoint Combinations" navigate to the Providers tab
<img width="1256" height="686" alt="Screenshot 2026-01-21 at 11 43 25" src="https://github.com/user-attachments/assets/57c66010-8827-4125-9ca3-df8afcf7c4f3" />
<img width="1255" height="699" alt="Screenshot 2026-01-21 at 11 43 43" src="https://github.com/user-attachments/assets/b7c857d9-9553-439b-b27b-44357df9f2c8" />

