### PR TITLE
fix: stack filter inputs vertically on mobile

### DIFF
--- a/src/App.svelte
+++ b/src/App.svelte
@@ -833,9 +833,13 @@ We also need to update [${RESOURCE_BACKUP_NAME}](https://github.com/${REPO_FULL_
       width: 100%;
     }
 
+    .filters-row {
+      grid-template-columns: 1fr;
+    }
+
     .filter-input {
       flex: 1;
-      width: auto;
+      width: 100%;
     }
 
     th, td {


### PR DESCRIPTION
## Summary
- Stack `.filters-row` filter inputs vertically on mobile (`max-width: 768px`)

<img width="437" height="696" alt="Screenshot 2026-02-09 at 19 29 54" src="https://github.com/user-attachments/assets/f033d393-6d9f-4001-9205-7fa074c34c41" />


Closes #10